### PR TITLE
gemspec cleanup: Require Ruby 2.2+, depend on mixlib-shellout, and add homepage to the gemspec

### DIFF
--- a/mixlib-platform.gemspec
+++ b/mixlib-platform.gemspec
@@ -1,22 +1,22 @@
-# coding: utf-8
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+$:.unshift(File.dirname(__FILE__) + "/lib")
 require "mixlib/platform/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "mixlib-platform"
   spec.version       = Mixlib::Platform::VERSION
+  spec.summary       = "A mixin for detecting the platform of a system"
+  spec.description   = spec.summary
   spec.authors       = ["Tim Smith"]
   spec.email         = ["tsmith@chef.io"]
+  spec.homepage      = "https://www.github.com/mixlib-platorm"
+  spec.license       = "Apache-2.0"
 
-  spec.summary       = "A mixin for detecting the platform of a system"
+  spec.files         = %w{LICENSE} + Dir.glob("lib/**/*")
+  spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
+  spec.require_paths = %w{lib}
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 2.2.2"
 
   spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_dependency 'mixlib-shellout' ">= 2.0"
 end


### PR DESCRIPTION
Other misc gemspec cleanup

Signed-off-by: Tim Smith <tsmith@chef.io>